### PR TITLE
README: add hint that vala needs to be built with meson

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,7 @@ More information about Vala is available at [https://wiki.gnome.org/Projects/Val
 Instructions on how to build the latest version of Vala.
 These can be modified to build a specific release.
 
-**NOTE** For the frida build, meson should be used instead of
-autoconf and make!
+**NOTE** For the Frida build, Meson should be used instead of autotools.
 
 ### Step One:
 Install the following packages:

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ More information about Vala is available at [https://wiki.gnome.org/Projects/Val
 Instructions on how to build the latest version of Vala.
 These can be modified to build a specific release.
 
+**NOTE** For the frida build, meson should be used instead of
+autoconf and make!
+
 ### Step One:
 Install the following packages:
 


### PR DESCRIPTION
The meson build adds -frida to the version string, while the autoconf&make build does not. During the build of frida-core, it verifies that valac's version string ends with -frida, and vala can hence not be built with autoconf&make.

See also complementary PR in frida-core: https://github.com/frida/frida-core/pull/1182